### PR TITLE
downcase RHEL in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can pass the following Terraform variables during `terraform apply` or
 in a `terraform.tfvars` file. Examples below:
 
 - `environment_name` = "network-test"
-- `os` = "RHEL"
+- `os` = "rhel"
 - `os_version` = "7.3"
 - `ssh_key_name` = "test_aws"
 


### PR DESCRIPTION
In order for a successful plan, the `os` var needs to be downcased. 

Updated `README.md` with correct `os` var declaration. 