### PR TITLE
make the lookup for bastion username use lower case

### DIFF
--- a/_interface.tf
+++ b/_interface.tf
@@ -88,7 +88,7 @@ output "security_group_bastion_id" {
 }
 
 output "bastion_username" {
-  value = "${lookup(var.user,var.os)}"
+  value = "${lookup(var.user,lower(var.os))}"
 }
 
 output "bastion_ips_public" {


### PR DESCRIPTION
I was running into odd corner cases where various modules were expecting lower case OS names while other were expecting first letter cap. That would alternately cause problems when looking up bastion usernames and/or AMIs. This appears to have fixed all known corners cases for me. 

A very heavyweight PR. I hope you guys can keep this all in your head for the merge review. ;)